### PR TITLE
set umask for pkgdb creation/access 

### DIFF
--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -92,7 +92,7 @@ xbps_pkgdb_lock(struct xbps_handle *xhp)
 		}
 	}
 
-	prev_umask = umask(0644);
+	prev_umask = umask(022);
 	if ((pkgdb_fd = open(xhp->pkgdb_plist, O_CREAT|O_RDWR|O_CLOEXEC, 0664)) == -1) {
 		rv = errno;
 		xbps_dbg_printf(xhp, "[pkgdb] cannot open pkgdb for locking "


### PR DESCRIPTION
This commit adds setting the process umask to 0664 prior to opening/creating so that pkgdb remains readable for world, even if xbps tools have been called with a very restrictive umask (like through sudo by a user with a umask 0700).

Maybe this behavior should be settable through a configuration option or a environment variable.