### PR TITLE
xbps-create: do not add a build-date property to packages.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ xbps-0.48 (???):
 
  * xbps-create(1): do not add a build-date property to packages.
 
+ * xbps-rindex(1): use mtime of file instead of the build-date field in the
+   package to set build-date in the repo index.
+
 xbps-0.47 (2015-07-18):
 
  * When executing pkg configuration, override the umask with sane defaults.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ xbps-0.48 (???):
    extra alphanumeric characters in the `reverts' object. Added a new testcase
    to verify its correctness.
 
+ * xbps-create(1): do not add a build-date property to packages.
+
 xbps-0.47 (2015-07-18):
 
  * When executing pkg configuration, override the umask with sane defaults.

--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -585,24 +585,6 @@ process_archive(struct archive *ar,
 	}
 }
 
-static void
-set_build_date(void)
-{
-	char outstr[64];
-	time_t t;
-	struct tm *tmp;
-
-	t = time(NULL);
-	tmp = localtime(&t);
-	assert(tmp);
-
-	if (strftime(outstr, sizeof(outstr)-1, "%F %R %Z", tmp) == 0)
-		die("failed to set build-date object (strftime):");
-
-	if (!xbps_dictionary_set_cstring(pkg_propsd, "build-date", outstr))
-		die("failed to add build-date object:");
-}
-
 int
 main(int argc, char **argv)
 {
@@ -778,7 +760,6 @@ main(int argc, char **argv)
 	xbps_dictionary_set_cstring_nocopy(pkg_propsd, "version", version);
 	xbps_dictionary_set_cstring_nocopy(pkg_propsd, "pkgver", pkgver);
 	xbps_dictionary_set_cstring_nocopy(pkg_propsd, "short_desc", desc);
-	set_build_date();
 
 	/* Optional properties */
 	if (homepage)

--- a/data/_xbps
+++ b/data/_xbps
@@ -14,7 +14,6 @@ _xbps_properties=(
 	architecture
 	archive-compression-type
 	automatic-install
-	build-date
 	build-options
 	conf_files
 	conflicts

--- a/data/xbps.bash
+++ b/data/xbps.bash
@@ -45,7 +45,6 @@ _xbps_complete() {
 	local props='architecture
 		archive-compression-type
 		automatic-install
-		build-date
 		build-options
 		conf_files
 		conflicts

--- a/doc/xbps_pkg_props_dictionary.dot
+++ b/doc/xbps_pkg_props_dictionary.dot
@@ -29,10 +29,6 @@ digraph pkg_props_dictionary {
 	instsize -> instsize_value;
 	instsize_value [style=filled,fillcolor="yellowgreen",label="389120"];
 	instsize [label="installed_size"];
-	main -> builddate [label="string"];
-	builddate [label="build_date"];
-	builddate -> builddate_value;
-	builddate_value [style=filled,fillcolor="yellowgreen",label="Friday 27 May, 2011, 06:58:13 UTC"];
 	main -> short_desc [label="string"]
 	short_desc -> shortdesc_val;
 	shortdesc_val [style=filled,fillcolor="yellowgreen",label="The XBPS package system utilities"];


### PR DESCRIPTION
Removes the build-date property as discussed in #110. closes #110.