### PR TITLE
xbps-query: fail on trailing parameters.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 xbps-0.48 (???):
 
+ * xbps-query(1): fail if unused arguments are supplied.
+
  * libxbps: relative cachedir set via xbps.d(5) now work correctly.
    Fixes #117 (https://github.com/voidlinux/xbps/issues/117)
 

--- a/bin/xbps-query/main.c
+++ b/bin/xbps-query/main.c
@@ -221,7 +221,12 @@ main(int argc, char **argv)
 	} else if (!opmode) {
 		/* show mode by default */
 		show = opmode = true;
-		pkg = *argv;
+		pkg = *(argv++);
+		argc--;
+	}
+	if (argc) {
+		/* trailing parameters */
+		usage(true);
 	}
 	/*
 	 * Initialize libxbps.


### PR DESCRIPTION
Currently if a user missused the xbps-query commando it's able to silently print the wrong results, e.g.:
```
xbps-query -s -R foobar
```
This command searches for the string "-R" and completely ignores the foobar at the end. This changes will let the command fail if there are trailing arguments.