### PR TITLE
freebsd build

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,4 +9,4 @@ Steve Prybylski
 Wolfgang Draxinger
 Bheesham Persaud
 Joey Gouly
-Michael Ghering
+Michael Gehring

--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -954,7 +954,11 @@ main(int argc, char **argv)
 	 */
 	binpkg = xbps_xasprintf("%s.%s.xbps", pkgver, arch);
 
+#ifdef HAVE_FDATASYNC
 	(void)fdatasync(pkg_fd);
+#else
+	(void)fsync(pkg_fd);
+#endif
 	myumask = umask(0);
 	(void)umask(myumask);
 

--- a/bin/xbps-rindex/repoflush.c
+++ b/bin/xbps-rindex/repoflush.c
@@ -86,7 +86,11 @@ repodata_flush(struct xbps_handle *xhp, const char *repodir,
 
 	/* Write data to tempfile and rename */
 	archive_write_finish(ar);
+#ifdef HAVE_FDATASYNC
 	fdatasync(repofd);
+#else
+	fsync(repofd);
+#endif
 	assert(fchmod(repofd, 0664) != -1);
 	close(repofd);
 	rename(tname, repofile);

--- a/configure
+++ b/configure
@@ -475,6 +475,27 @@ fi
 rm -f _$func.c _$func
 
 #
+# Check for strnstr().
+func=strnstr
+printf "Checking for $func() ... "
+cat <<EOF > _$func.c
+#include <string.h>
+int main(void) {
+	const char big[] = "foo";
+	const char little[] = "f";
+	strnstr(big, little, 3);
+	return 0;
+}
+EOF
+if $XCC _$func.c -o _$func 2>/dev/null; then
+	echo yes.
+	echo "CPPFLAGS +=	-DHAVE_STRNSTR" >>$CONFIG_MK
+else
+	echo no.
+fi
+rm -f _$func.c _$func
+
+#
 # Check for humanize_number().
 func=humanize_number
 printf "Checking for $func() ... "

--- a/lib/fetch/common.c
+++ b/lib/fetch/common.c
@@ -444,6 +444,8 @@ fetch_cache_put(conn_t *conn, int (*closecb)(conn_t *))
 
 
 #ifdef WITH_SSL
+
+#ifndef HAVE_STRNSTR
 /*
  * Find the first occurrence of find in s, where the search is limited to the
  * first slen characters of s.
@@ -468,6 +470,7 @@ strnstr(const char *s, const char *find, size_t slen)
 	}
 	return ((char *)__UNCONST(s));
 }
+#endif
 
 /*
  * Convert characters A-Z to lowercase (intentionally avoid any locale

--- a/lib/initend.c
+++ b/lib/initend.c
@@ -26,6 +26,9 @@
 
 #include <sys/utsname.h>
 #include <sys/types.h>
+#ifdef __FreeBSD__
+#define _WITH_GETLINE   /* getline() */
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #define _BSD_SOURCE	/* required by strlcpy with musl */

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -150,7 +150,7 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 	cnt = xbps_array_count(a);
 	for (i = 0; i < cnt; i++) {
 		xbps_string_t str;
-		char *tgt_dup, *tgt_dir, *lnk_dup, *lnk_dir;
+		char *tgt_dup, *tgt_dir, *tgt_dir_dup, *lnk_dup, *lnk_dir;
 		char *l, *lnk, *tgt = NULL;
 		const char *tgt0;
 		int rv;
@@ -164,6 +164,7 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 		tgt_dup = strdup(tgt0);
 		assert(tgt_dup);
 		tgt_dir = dirname(tgt_dup);
+		tgt_dir_dup = strdup(tgt_dir);
 		if (strcmp(tgt_dir, ".")) {
 			tgt = xbps_xasprintf("%s%s", xhp->rootdir, tgt_dir);
 			if (xbps_mkpath(tgt, 0755) != 0) {
@@ -172,6 +173,7 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 					xbps_dbg_printf(xhp, "failed to create "
 					    "target dir '%s' for group '%s': %s\n",
 					    tgt, grname, strerror(errno));
+					free(tgt_dir_dup);
 					free(tgt_dup);
 					free(tgt);
 					free(l);
@@ -192,6 +194,7 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 					xbps_dbg_printf(xhp, "failed to create symlink"
 					    "dir '%s' for group '%s': %s\n",
 					    lnk, grname, strerror(errno));
+					free(tgt_dir_dup);
 					free(tgt_dup);
 					free(lnk_dup);
 					free(lnk);
@@ -204,7 +207,7 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 		free(lnk_dup);
 
 		if (l[0] != '/') {
-			lnk = xbps_xasprintf("%s%s/%s", xhp->rootdir, tgt_dir, l);
+			lnk = xbps_xasprintf("%s%s/%s", xhp->rootdir, tgt_dir_dup, l);
 			free(tgt_dup);
 			tgt_dup = strdup(tgt0);
 			assert(tgt_dup);
@@ -215,6 +218,7 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 			tgt = strdup(tgt0);
 			lnk = xbps_xasprintf("%s%s", xhp->rootdir, l);
 		}
+		free(tgt_dir_dup);
 		xbps_set_cb_state(xhp, XBPS_STATE_ALTGROUP_LINK_ADDED, 0, NULL,
 		    "Creating '%s' alternatives group symlink: %s -> %s", grname, l, tgt);
 		unlink(lnk);

--- a/lib/package_script.c
+++ b/lib/package_script.c
@@ -87,7 +87,11 @@ xbps_pkg_exec_buffer(struct xbps_handle *xhp,
 		goto out;
 	}
 	fchmod(fd, 0750);
+#ifdef HAVE_FDATASYNC
 	fdatasync(fd);
+#else
+	fsync(fd);
+#endif
 	close(fd);
 
 	/* exec script */


### PR DESCRIPTION
Fixes the build on FreeBSD (10.3+ only atm, earlier versions are missing
futimens/utimensat and need some more work).

This actually passes the testsuite, but the testsuite needs some adjustments
for differing output/behaviour of `sed`,`wc` and `errno` values. See 
 my [freebsd-tests](/ebfe/xbps/tree/freebsd-tests) branch