### PR TITLE
xbps-rindex: check for consistent shlibs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,12 @@ xbps-0.52 (???):
  * xbps-query(1): fix a bug where the output of -o became mixed up
    when running on multiple cores.
 
+ * xbps-rindex: changes introducing inconsistent shlib dependencies will be
+   moved to a stage area and moved to the main repo once all inconsistencies
+   are resolved. Implemented by Enno Boland (@Gottox).
+
+ * libxbps: if a local repository is opened also include the stage area.
+
 xbps-0.51 (2015-12-12):
 
  * zsh completion: added -U/--unpack-only support for xbps-install(1).

--- a/bin/xbps-rindex/defs.h
+++ b/bin/xbps-rindex/defs.h
@@ -81,7 +81,7 @@ int	sign_repo(struct xbps_handle *, const char *, const char *,
 int	sign_pkgs(struct xbps_handle *, int, int, char **, const char *, bool);
 
 /* From repoflush.c */
-bool	repodata_flush(struct xbps_handle *, const char *,
+bool	repodata_flush(struct xbps_handle *, const char *, const char *,
 		xbps_dictionary_t, xbps_dictionary_t);
 
 #endif /* !_XBPS_RINDEX_DEFS_H_ */

--- a/bin/xbps-rindex/index-add.c
+++ b/bin/xbps-rindex/index-add.c
@@ -134,7 +134,7 @@ repodata_commit(struct xbps_handle *xhp, const char *repodir,
 	xbps_object_iterator_release(iter);
 
 	if (xbps_dictionary_count(usedshlibs) != 0) {
-		puts("Inconsistent shlibs:");
+		printf("Inconsistent shlibs:\n");
 		iter = xbps_dictionary_iterator(usedshlibs);
 		while ((keysym = xbps_object_iterator_next(iter))) {
 			const char *shlib = xbps_dictionary_keysym_cstring_nocopy(keysym),
@@ -151,9 +151,9 @@ repodata_commit(struct xbps_handle *xhp, const char *repodir,
 				printf("%s%s",pre, user);
 				pre = ", ";
 			}
-			puts(")");
+			printf(")\n");
 		}
-		puts("Packages are added to stage area.");
+		printf("Packages are added to stage area.\n");
 		xbps_object_iterator_release(iter);
 		rv = repodata_flush(xhp, repodir, "stagedata", stage, NULL);
 	}

--- a/bin/xbps-rindex/index-add.c
+++ b/bin/xbps-rindex/index-add.c
@@ -54,16 +54,140 @@ set_build_date(const xbps_dictionary_t pkgd, time_t timestamp)
 	return 0;
 }
 
+static bool
+repodata_commit(struct xbps_handle *xhp, const char *repodir,
+	xbps_dictionary_t idx, xbps_dictionary_t meta, xbps_dictionary_t stage) {
+	xbps_object_iterator_t iter;
+	xbps_object_t keysym;
+	int rv;
+	xbps_dictionary_t oldshlibs, usedshlibs;
+
+	if (xbps_dictionary_count(stage) == 0) {
+		// Nothing to do.
+		return true;
+	}
+
+	/*
+	 * Find old shlibs-provides
+	 */
+	oldshlibs = xbps_dictionary_create();
+	usedshlibs = xbps_dictionary_create();
+
+	iter = xbps_dictionary_iterator(stage);
+	while ((keysym = xbps_object_iterator_next(iter))) {
+		const char *pkgname = xbps_dictionary_keysym_cstring_nocopy(keysym);
+		xbps_dictionary_t pkg = xbps_dictionary_get(idx, pkgname);
+		xbps_array_t pkgshlibs;
+
+		pkgshlibs = xbps_dictionary_get(pkg, "shlib-provides");
+		for (unsigned int i = 0; i < xbps_array_count(pkgshlibs); i++) {
+			const char *shlib = NULL;
+			xbps_array_get_cstring_nocopy(pkgshlibs, i, &shlib);
+			xbps_dictionary_set_cstring(oldshlibs, shlib, pkgname);
+		}
+	}
+	xbps_object_iterator_release(iter);
+
+	/*
+	 * throw away all unused shlibs
+	 */
+	iter = xbps_dictionary_iterator(idx);
+	while ((keysym = xbps_object_iterator_next(iter))) {
+		const char *pkgname = xbps_dictionary_keysym_cstring_nocopy(keysym);
+		xbps_dictionary_t pkg = xbps_dictionary_get(stage, pkgname);
+		xbps_array_t pkgshlibs;
+		if (!pkg)
+			pkg = xbps_dictionary_get_keysym(idx, keysym);
+		pkgshlibs = xbps_dictionary_get(pkg, "shlib-requires");
+
+		for (unsigned int i = 0; i < xbps_array_count(pkgshlibs); i++) {
+			const char *shlib = NULL;
+			xbps_array_t users;
+			xbps_array_get_cstring_nocopy(pkgshlibs, i, &shlib);
+			if (!xbps_dictionary_get(oldshlibs, shlib))
+				continue;
+			users = xbps_dictionary_get(usedshlibs, shlib);
+			if (!users) {
+				users = xbps_array_create();
+				xbps_dictionary_set(usedshlibs, shlib, users);
+			}
+			xbps_array_add_cstring(users, pkgname);
+		}
+	}
+	xbps_object_iterator_release(iter);
+
+	/*
+	 * purge all packages that are fullfilled by the stage
+	 */
+	iter = xbps_dictionary_iterator(stage);
+	while ((keysym = xbps_object_iterator_next(iter))) {
+		xbps_dictionary_t pkg = xbps_dictionary_get_keysym(stage, keysym);
+		xbps_array_t pkgshlibs;
+
+		pkgshlibs = xbps_dictionary_get(pkg, "shlib-provides");
+		for (unsigned int i = 0; i < xbps_array_count(pkgshlibs); i++) {
+			const char *shlib;
+			xbps_array_get_cstring_nocopy(pkgshlibs, i, &shlib);
+			xbps_dictionary_remove(usedshlibs, shlib);
+		}
+	}
+	xbps_object_iterator_release(iter);
+
+	if (xbps_dictionary_count(usedshlibs) != 0) {
+		puts("Inconsistent shlibs:");
+		iter = xbps_dictionary_iterator(usedshlibs);
+		while ((keysym = xbps_object_iterator_next(iter))) {
+			const char *shlib = xbps_dictionary_keysym_cstring_nocopy(keysym),
+					*provider = NULL, *pre;
+			xbps_array_t users = xbps_dictionary_get(usedshlibs, shlib);
+			xbps_dictionary_get_cstring_nocopy(oldshlibs, shlib, &provider);
+
+			printf(" %s (provided by: %s; used by: ", shlib, provider);
+			pre = "";
+			for (unsigned int i = 0; i < xbps_array_count(users); i++) {
+				const char *user;
+				xbps_array_get_cstring_nocopy(users, i, &user);
+				xbps_dictionary_remove(usedshlibs, shlib);
+				printf("%s%s",pre, user);
+				pre = ", ";
+			}
+			puts(")");
+		}
+		puts("Packages are added to stage area.");
+		xbps_object_iterator_release(iter);
+		rv = repodata_flush(xhp, repodir, "stagedata", stage, NULL);
+	}
+	else {
+		char *stagefile;
+		iter = xbps_dictionary_iterator(stage);
+		while ((keysym = xbps_object_iterator_next(iter))) {
+			const char *pkgname = xbps_dictionary_keysym_cstring_nocopy(keysym);
+			xbps_dictionary_t pkg = xbps_dictionary_get_keysym(stage, keysym);
+			const char *pkgver, *arch;
+			xbps_dictionary_get_cstring_nocopy(pkg, "pkgver", &pkgver);
+			xbps_dictionary_get_cstring_nocopy(pkg, "architecture", &arch);
+			printf("index: added `%s' (%s).\n", pkgver, arch);
+			xbps_dictionary_set(idx, pkgname, pkg);
+		}
+		xbps_object_iterator_release(iter);
+		stagefile = xbps_repo_path_with_name(xhp, repodir, "stagedata");
+		unlink(stagefile);
+		free(stagefile);
+		rv = repodata_flush(xhp, repodir, "repodata", idx, meta);
+	}
+	xbps_object_release(usedshlibs);
+	xbps_object_release(oldshlibs);
+	return rv;
+}
 
 int
 index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force)
 {
-	xbps_dictionary_t idx, idxmeta, binpkgd, curpkgd;
-	struct xbps_repo *repo = NULL;
+	xbps_dictionary_t idx, idxmeta, idxstage, binpkgd, curpkgd;
+	struct xbps_repo *repo = NULL, *stage = NULL;
 	struct stat st;
 	char *tmprepodir = NULL, *repodir = NULL, *rlockfname = NULL;
 	int rv = 0, ret = 0, rlockfd = -1;
-	bool flush = false;
 
 	assert(argv);
 	/*
@@ -79,7 +203,7 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 		rv = -1;
 		goto out;
 	}
-	repo = xbps_repo_open(xhp, repodir);
+	repo = xbps_repo_public_open(xhp, repodir);
 	if (repo == NULL && errno != ENOENT) {
 		fprintf(stderr, "xbps-rindex: cannot open/lock repository "
 		    "%s: %s\n", repodir, strerror(errno));
@@ -92,6 +216,19 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 	} else {
 		idx = xbps_dictionary_create();
 		idxmeta = NULL;
+	}
+	stage = xbps_repo_stage_open(xhp, repodir);
+	if (stage == NULL && errno != ENOENT) {
+		fprintf(stderr, "xbps-rindex: cannot open/lock stage repository "
+		    "%s: %s\n", repodir, strerror(errno));
+		rv = -1;
+		goto out;
+	}
+	if (stage) {
+		idxstage = xbps_dictionary_copy_mutable(stage->idx);
+	}
+	else {
+		idxstage = xbps_dictionary_create();
 	}
 	/*
 	 * Process all packages specified in argv.
@@ -126,7 +263,9 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 		 * than current registered package, update the index; otherwise
 		 * pass to the next one.
 		 */
-		curpkgd = xbps_dictionary_get(idx, pkgname);
+		curpkgd = xbps_dictionary_get(idxstage, pkgname);
+		if (curpkgd == NULL)
+			curpkgd = xbps_dictionary_get(idx, pkgname);
 		if (curpkgd == NULL) {
 			if (errno && errno != ENOENT) {
 				rv = errno;
@@ -166,12 +305,6 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 				free(pkgname);
 				continue;
 			}
-			/*
-			 * Current package version is greater than
-			 * index version.
-			 */
-			printf("index: removed obsolete entry `%s' (%s).\n", opkgver, oarch);
-			xbps_dictionary_remove(idx, pkgname);
 			free(opkgver);
 			free(oarch);
 		}
@@ -218,16 +351,14 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 		xbps_dictionary_remove(binpkgd, "packaged-with");
 
 		/*
-		 * Add new pkg dictionary into the index.
+		 * Add new pkg dictionary into the stage index
 		 */
-		if (!xbps_dictionary_set(idx, pkgname, binpkgd)) {
+		if (!xbps_dictionary_set(idxstage, pkgname, binpkgd)) {
 			free(pkgname);
 			free(pkgver);
 			rv = EINVAL;
 			goto out;
 		}
-		flush = true;
-		printf("index: added `%s' (%s).\n", pkgver, arch);
 		xbps_object_release(binpkgd);
 		free(pkgname);
 		free(pkgver);
@@ -235,18 +366,18 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 	/*
 	 * Generate repository data files.
 	 */
-	if (flush) {
-		if (!repodata_flush(xhp, repodir, idx, idxmeta)) {
-			fprintf(stderr, "%s: failed to write repodata: %s\n",
-			    _XBPS_RINDEX, strerror(errno));
-			goto out;
-		}
+	if (!repodata_commit(xhp, repodir, idx, idxmeta, idxstage)) {
+		fprintf(stderr, "%s: failed to write repodata: %s\n",
+				_XBPS_RINDEX, strerror(errno));
+		goto out;
 	}
 	printf("index: %u packages registered.\n", xbps_dictionary_count(idx));
 
 out:
 	if (repo)
 		xbps_repo_close(repo);
+	if (stage)
+		xbps_repo_close(stage);
 
 	xbps_repo_unlock(rlockfd, rlockfname);
 

--- a/bin/xbps-rindex/index-clean.c
+++ b/bin/xbps-rindex/index-clean.c
@@ -134,7 +134,7 @@ index_clean(struct xbps_handle *xhp, const char *repodir)
 	xbps_object_release(allkeys);
 
 	if (!xbps_dictionary_equals(dest, repo->idx)) {
-		if (!repodata_flush(xhp, repodir, dest, repo->idxmeta)) {
+		if (!repodata_flush(xhp, repodir, "repodata", dest, repo->idxmeta)) {
 			rv = errno;
 			fprintf(stderr, "failed to write repodata: %s\n",
 			    strerror(errno));

--- a/bin/xbps-rindex/index-clean.c
+++ b/bin/xbps-rindex/index-clean.c
@@ -101,6 +101,11 @@ cleanup_repo(struct xbps_handle *xhp, const char *repodir, struct xbps_repo *rep
 	(void)xbps_array_foreach_cb_multi(xhp, allkeys, repo->idx, idx_cleaner_cb, __UNCONST(repodir));
 	xbps_object_release(allkeys);
 
+	if(strcmp("stagedata", reponame) == 0 && xbps_dictionary_count(dest) == 0) {
+		char *stagefile = xbps_repo_path_with_name(xhp, repodir, "stagedata");
+		unlink(stagefile);
+		free(stagefile);
+	}
 	if (!xbps_dictionary_equals(dest, repo->idx)) {
 		if (!repodata_flush(xhp, repodir, reponame, dest, repo->idxmeta)) {
 			rv = errno;

--- a/bin/xbps-rindex/repoflush.c
+++ b/bin/xbps-rindex/repoflush.c
@@ -39,7 +39,7 @@
 
 bool
 repodata_flush(struct xbps_handle *xhp, const char *repodir,
-	xbps_dictionary_t idx, xbps_dictionary_t meta)
+	const char *reponame, xbps_dictionary_t idx, xbps_dictionary_t meta)
 {
 	struct archive *ar;
 	char *repofile, *tname, *buf;
@@ -47,7 +47,7 @@ repodata_flush(struct xbps_handle *xhp, const char *repodir,
 	mode_t mask;
 
 	/* Create a tempfile for our repository archive */
-	repofile = xbps_repo_path(xhp, repodir);
+	repofile = xbps_repo_path_with_name(xhp, repodir, reponame);
 	tname = xbps_xasprintf("%s.XXXXXXXXXX", repofile);
 	mask = umask(S_IXUSR|S_IRWXG|S_IRWXO);
 	if ((repofd = mkstemp(tname)) == -1)

--- a/bin/xbps-rindex/sign.c
+++ b/bin/xbps-rindex/sign.c
@@ -224,7 +224,7 @@ sign_repo(struct xbps_handle *xhp, const char *repodir,
 		    _XBPS_RINDEX, strerror(errno));
 		goto out;
 	}
-	flush_failed = repodata_flush(xhp, repodir, repo->idx, meta);
+	flush_failed = repodata_flush(xhp, repodir, "repodata", repo->idx, meta);
 	xbps_repo_unlock(rlockfd, rlockfname);
 	if (!flush_failed) {
 		fprintf(stderr, "failed to write repodata: %s\n", strerror(errno));

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -1500,6 +1500,26 @@ void xbps_repo_unlock(int lockfd, char *lockfname);
 struct xbps_repo *xbps_repo_open(struct xbps_handle *xhp, const char *url);
 
 /**
+ * Opens a staging repository and returns a xbps_repo object.
+ *
+ * @param[in] xhp Pointer to the xbps_handle struct.
+ * @param[in] uri Repository URI to match.
+ *
+ * @return The matching repository object, NULL otherwise.
+ */
+struct xbps_repo *xbps_repo_stage_open(struct xbps_handle *xhp, const char *url);
+
+/**
+ * Opens a repository and returns a xbps_repo object.
+ *
+ * @param[in] xhp Pointer to the xbps_handle struct.
+ * @param[in] uri Repository URI to match.
+ *
+ * @return The matching repository object, NULL otherwise.
+ */
+struct xbps_repo *xbps_repo_public_open(struct xbps_handle *xhp, const char *url);
+
+/**
  * Closes a repository object and releases resources.
  *
  * @param[in] repo The repository object to close.
@@ -1516,6 +1536,18 @@ void xbps_repo_close(struct xbps_repo *repo);
  * @return A heap allocated string that must be free(3)d when it's unneeded.
  */
 char *xbps_repo_path(struct xbps_handle *xhp, const char *url);
+
+/**
+ *
+ * Returns a heap-allocated string with the repository local path.
+ *
+ * @param[in] xhp The xbps_handle object.
+ * @param[in] url The repository URL to match.
+ * @param[in] name The repository name (stage or repodata)
+ *
+ * @return A heap allocated string that must be free(3)d when it's unneeded.
+ */
+char *xbps_repo_path_with_name(struct xbps_handle *xhp, const char *url, const char *name);
 
 /**
  * Remotely fetch repository data and keep it in memory.

--- a/lib/repo.c
+++ b/lib/repo.c
@@ -47,11 +47,18 @@
 char *
 xbps_repo_path(struct xbps_handle *xhp, const char *url)
 {
+	return xbps_repo_path_with_name(xhp, url, "repodata");
+}
+
+char *
+xbps_repo_path_with_name(struct xbps_handle *xhp, const char *url, const char *name)
+{
 	assert(xhp);
 	assert(url);
+	assert(strcmp(name, "repodata") == 0 || strcmp(name, "stagedata") == 0);
 
-	return xbps_xasprintf("%s/%s-repodata",
-	    url, xhp->target_arch ? xhp->target_arch : xhp->native_arch);
+	return xbps_xasprintf("%s/%s-%s",
+	    url, xhp->target_arch ? xhp->target_arch : xhp->native_arch, name);
 }
 
 static xbps_dictionary_t
@@ -182,6 +189,72 @@ repo_open_remote(struct xbps_repo *repo)
 	return rv;
 }
 
+static struct xbps_repo *
+repo_open_with_type(struct xbps_handle *xhp, const char *url, const char *name)
+{
+	struct xbps_repo *repo;
+	const char *arch;
+	char *repofile;
+
+	assert(xhp);
+	assert(url);
+
+	if (xhp->target_arch)
+		arch = xhp->target_arch;
+	else
+		arch = xhp->native_arch;
+
+	repo = calloc(1, sizeof(struct xbps_repo));
+	assert(repo);
+	repo->fd = -1;
+	repo->xhp = xhp;
+	repo->uri = url;
+
+	if (xbps_repository_is_remote(url)) {
+		/* remote repository */
+		char *rpath;
+
+		if ((rpath = xbps_get_remote_repo_string(url)) == NULL) {
+			free(repo);
+			return NULL;
+		}
+		repofile = xbps_xasprintf("%s/%s/%s-%s", xhp->metadir, rpath, arch, name);
+		free(rpath);
+		repo->is_remote = true;
+	} else {
+		/* local repository */
+		repofile = xbps_repo_path_with_name(xhp, url, name);
+	}
+	/*
+	 * In memory repo sync.
+	 */
+	if (repo->is_remote && (xhp->flags & XBPS_FLAG_REPOS_MEMSYNC)) {
+		if (repo_open_remote(repo))
+			return repo;
+
+		goto out;
+	}
+	/*
+	 * Open the repository archive.
+	 */
+	repo->fd = open(repofile, O_RDONLY|O_CLOEXEC);
+	if (repo->fd == -1) {
+		int rv = errno;
+		xbps_dbg_printf(xhp, "[repo] `%s' open %s %s\n",
+		    repofile, name, strerror(rv));
+		goto out;
+	}
+	if (repo_open_local(repo, repofile)) {
+		free(repofile);
+		return repo;
+	}
+
+out:
+	free(repofile);
+	xbps_repo_close(repo);
+	return NULL;
+}
+
 bool
 xbps_repo_store(struct xbps_handle *xhp, const char *repo)
 {
@@ -222,69 +295,45 @@ xbps_repo_store(struct xbps_handle *xhp, const char *repo)
 }
 
 struct xbps_repo *
+xbps_repo_stage_open(struct xbps_handle *xhp, const char *url)
+{
+	return repo_open_with_type(xhp, url, "stagedata");
+}
+
+struct xbps_repo *
+xbps_repo_public_open(struct xbps_handle *xhp, const char *url) {
+	return repo_open_with_type(xhp, url, "repodata");
+}
+
+struct xbps_repo *
 xbps_repo_open(struct xbps_handle *xhp, const char *url)
 {
-	struct xbps_repo *repo;
-	const char *arch;
-	char *repofile;
-
-	assert(xhp);
-	assert(url);
-
-	if (xhp->target_arch)
-		arch = xhp->target_arch;
-	else
-		arch = xhp->native_arch;
-
-	repo = calloc(1, sizeof(struct xbps_repo));
-	assert(repo);
-	repo->fd = -1;
-	repo->xhp = xhp;
-	repo->uri = url;
-
-	if (xbps_repository_is_remote(url)) {
-		/* remote repository */
-		char *rpath;
-
-		if ((rpath = xbps_get_remote_repo_string(url)) == NULL) {
-			free(repo);
-			return NULL;
-		}
-		repofile = xbps_xasprintf("%s/%s/%s-repodata", xhp->metadir, rpath, arch);
-		free(rpath);
-		repo->is_remote = true;
-	} else {
-		/* local repository */
-		repofile = xbps_repo_path(xhp, url);
-	}
+	struct xbps_repo *repo = xbps_repo_public_open(xhp, url);
+	struct xbps_repo *stage = NULL;
+	xbps_dictionary_t idx;
+	const char *pkgname;
+	xbps_object_t keysym;
+	xbps_object_iterator_t iter;
 	/*
-	 * In memory repo sync.
+	 * Load and merge staging repository if the repository is local.
 	 */
-	if (repo->is_remote && (xhp->flags & XBPS_FLAG_REPOS_MEMSYNC)) {
-		if (repo_open_remote(repo))
+	if (!repo->is_remote) {
+		stage = xbps_repo_stage_open(xhp, url);
+		if (stage == NULL)
 			return repo;
-
-		goto out;
-	}
-	/*
-	 * Open the repository archive.
-	 */
-	repo->fd = open(repofile, O_RDONLY|O_CLOEXEC);
-	if (repo->fd == -1) {
-		int rv = errno;
-		xbps_dbg_printf(xhp, "[repo] `%s' open repodata %s\n",
-		    repofile, strerror(rv));
-		goto out;
-	}
-	if (repo_open_local(repo, repofile)) {
-		free(repofile);
+		idx = xbps_dictionary_copy_mutable(repo->idx);
+		iter = xbps_dictionary_iterator(stage->idx);
+		while ((keysym = xbps_object_iterator_next(iter))) {
+			pkgname = xbps_dictionary_keysym_cstring_nocopy(keysym);
+			xbps_dictionary_set(idx, pkgname,
+					xbps_dictionary_get_keysym(stage->idx, keysym));
+		}
+		xbps_object_iterator_release(iter);
+		xbps_object_release(repo->idx);
+		repo->idx = idx;
 		return repo;
 	}
-
-out:
-	free(repofile);
-	xbps_repo_close(repo);
-	return NULL;
+	return repo;
 }
 
 void

--- a/tests/xbps/xbps-rindex/Kyuafile
+++ b/tests/xbps/xbps-rindex/Kyuafile
@@ -3,3 +3,4 @@ syntax("kyuafile", 1)
 test_suite("xbps-rindex")
 atf_test_program{name="add_test"}
 atf_test_program{name="clean_test"}
+atf_test_program{name="remove_test"}

--- a/tests/xbps/xbps-rindex/Makefile
+++ b/tests/xbps/xbps-rindex/Makefile
@@ -1,7 +1,7 @@
 TOPDIR = ../../..
 -include $(TOPDIR)/config.mk
 
-TESTSHELL = add_test clean_test
+TESTSHELL = add_test clean_test remove_test
 TESTSSUBDIR = xbps/xbps-rindex
 EXTRA_FILES = Kyuafile
 

--- a/tests/xbps/xbps-rindex/add_test.sh
+++ b/tests/xbps/xbps-rindex/add_test.sh
@@ -62,7 +62,55 @@ revert_body() {
 	atf_check_equal $rv 0
 }
 
+atf_test_case stage
+
+stage_head() {
+	atf_set "descr" "xbps-rindex(8) -a: commit package to stage test"
+}
+
+stage_body() {
+	mkdir -p some_repo pkg_A pkg_B
+	touch pkg_A/file00 pkg_B/file01
+	cd some_repo
+	xbps-create -A noarch -n foo-1.0_1 -s "foo pkg" --shlib-provides "libfoo.so.1" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	[ -f *-stagedata ]
+	atf_check_equal $? 1
+
+	xbps-create -A noarch -n foo-1.1_1 -s "foo pkg" --shlib-provides "libfoo.so.2" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	[ -f *-stagedata ]
+	atf_check_equal $? 1
+
+	xbps-create -A noarch -n bar-1.0_1 -s "foo pkg" --shlib-requires "libfoo.so.2" ../pkg_B
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	[ -f *-stagedata ]
+	atf_check_equal $? 1
+
+	xbps-create -A noarch -n foo-1.2_1 -s "foo pkg" --shlib-provides "libfoo.so.3" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	[ -f *-stagedata ]
+	atf_check_equal $? 0
+
+	xbps-create -A noarch -n bar-1.1_1 -s "foo pkg" --shlib-requires "libfoo.so.3" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	[ -f *-stagedata ]
+	atf_check_equal $? 1
+}
+
+
 atf_init_test_cases() {
 	atf_add_test_case update
 	atf_add_test_case revert
+	atf_add_test_case stage
 }

--- a/tests/xbps/xbps-rindex/clean_test.sh
+++ b/tests/xbps/xbps-rindex/clean_test.sh
@@ -51,7 +51,36 @@ issue19_body() {
 	atf_check_equal $? 0
 }
 
+atf_test_case remove_from_stage
+
+remove_from_stage_head() {
+	atf_set "descr" "xbps-rindex(8) -r: don't removing if there's staging test"
+}
+
+remove_from_stage_body() {
+	mkdir -p some_repo pkg_A pkg_B
+	cd some_repo
+	xbps-create -A noarch -n foo-1.0_1 -s "foo pkg" --shlib-provides "foo.so.1" ../pkg_A
+	atf_check_equal $? 0
+	xbps-create -A noarch -n bar-1.0_1 -s "foo pkg" --shlib-requires "foo.so.1" ../pkg_B
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	xbps-create -A noarch -n foo-1.1_1 -s "foo pkg" --shlib-provides "foo.so.2" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	[ -f *-stagedata ]
+	atf_check_equal $? 0
+	rm foo-1.1_1*
+	cd ..
+	xbps-rindex -c some_repo
+	[ -f *-stagedata ]
+	atf_check_equal $? 1
+}
+
 atf_init_test_cases() {
 	atf_add_test_case noremove
 	atf_add_test_case issue19
+	atf_add_test_case remove_from_stage
 }

--- a/tests/xbps/xbps-rindex/remove_test.sh
+++ b/tests/xbps/xbps-rindex/remove_test.sh
@@ -1,0 +1,39 @@
+#! /usr/bin/env atf-sh
+# Test that xbps-rindex(8) -c (clean mode) works as expected.
+
+# 1st test: make sure that nothing is removed if there are no changes.
+atf_test_case noremove_stage
+
+noremove_stage_head() {
+	atf_set "descr" "xbps-rindex(8) -r: don't removing if there's staging test"
+}
+
+noremove_stage_body() {
+	mkdir -p some_repo pkg_A pkg_B
+	cd some_repo
+	xbps-create -A noarch -n foo-1.0_1 -s "foo pkg" --shlib-provides "foo.so.1" ../pkg_A
+	atf_check_equal $? 0
+	xbps-create -A noarch -n bar-1.0_1 -s "foo pkg" --shlib-requires "foo.so.1" ../pkg_B
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	xbps-create -A noarch -n foo-1.1_1 -s "foo pkg" --shlib-provides "foo.so.2" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	[ -f *-stagedata ]
+	atf_check_equal $? 0
+	xbps-rindex -r some_repo
+	atf_check_equal $? 0
+	cd some_repo
+	[ -f foo-1.0_1* ]
+	atf_check_equal $? 0
+	[ -f foo-1.1_1* ]
+	atf_check_equal $? 0
+	[ -f bar-1.0_1* ]
+	atf_check_equal $? 0
+}
+
+atf_init_test_cases() {
+	atf_add_test_case noremove_stage
+}


### PR DESCRIPTION
When adding packages to the index, xbps-rindex will check if the
consistency of shlibs is broken by a package. If so, rindex will create
a stage file and commit the packages there. Once the consistency
is restored, rindex -a will commit the stage area back to the public
repo and delete the stage file.

TODO:
* [x] serialize and deserialize stage area in xbps-rindex
* [x] update NEWS
* [x] write test cases for xbps-rindex to check if a package...
  * ...is correctly added to the stage area
  * ...is correctly removed from the stage area when the inconsistency is gone
* [x] write test cases for xbps-install to check if stagedata overwrites repodata on an local repository
* [x] write test cases for cleaning up the staging repository