### PR TITLE
lib/portableproplib: fix various oob reads/segfaults

### DIFF
--- a/lib/portableproplib/prop_object.c
+++ b/lib/portableproplib/prop_object.c
@@ -393,10 +393,11 @@ _prop_object_internalize_find_tag(struct _prop_object_internalize_context *ctx,
 
 	ctx->poic_tagname = cp;
 
-	while (!_PROP_ISSPACE(*cp) && *cp != '/' && *cp != '>')
+	while (!_PROP_ISSPACE(*cp) && *cp != '/' && *cp != '>') {
+		if (_PROP_EOF(*cp))
+			return (false);
 		cp++;
-	if (_PROP_EOF(*cp))
-		return (false);
+	}
 
 	ctx->poic_tagname_len = cp - ctx->poic_tagname;
 
@@ -439,10 +440,11 @@ _prop_object_internalize_find_tag(struct _prop_object_internalize_context *ctx,
 
 	ctx->poic_tagattr = cp;
 
-	while (!_PROP_ISSPACE(*cp) && *cp != '=')
+	while (!_PROP_ISSPACE(*cp) && *cp != '=') {
+		if (_PROP_EOF(*cp))
+			return (false);
 		cp++;
-	if (_PROP_EOF(*cp))
-		return (false);
+	}
 
 	ctx->poic_tagattr_len = cp - ctx->poic_tagattr;
 	
@@ -454,10 +456,11 @@ _prop_object_internalize_find_tag(struct _prop_object_internalize_context *ctx,
 		return (false);
 	
 	ctx->poic_tagattrval = cp;
-	while (*cp != '\"')
+	while (*cp != '\"') {
+		if (_PROP_EOF(*cp))
+			return (false);
 		cp++;
-	if (_PROP_EOF(*cp))
-		return (false);
+	}
 	ctx->poic_tagattrval_len = cp - ctx->poic_tagattrval;
 	
 	cp++;

--- a/lib/portableproplib/prop_object_impl.h
+++ b/lib/portableproplib/prop_object_impl.h
@@ -107,8 +107,7 @@ typedef enum {
 
 #define	_PROP_EOF(c)		((c) == '\0')
 #define	_PROP_ISSPACE(c)	\
-	((c) == ' ' || (c) == '\t' || (c) == '\n' || (c) == '\r' || \
-	 _PROP_EOF(c))
+	((c) == ' ' || (c) == '\t' || (c) == '\n' || (c) == '\r')
 
 #define	_PROP_TAG_MATCH(ctx, t)					\
 	_prop_object_internalize_match((ctx)->poic_tagname,	\


### PR DESCRIPTION
Applies the following patches from NetBSD:

http://cvsweb.netbsd.org/bsdweb.cgi/src/common/lib/libprop/prop_object.c?rev=1.30&content-type=text/x-cvsweb-markup
http://cvsweb.netbsd.org/bsdweb.cgi/src/common/lib/libprop/prop_object_impl.h?rev=1.31.12.1&content-type=text/x-cvsweb-markup