### PR TITLE
lib: dont call EVP_cleanup in fp2str

### DIFF
--- a/lib/pubkey2fp.c
+++ b/lib/pubkey2fp.c
@@ -160,8 +160,5 @@ out:
 	if (pEncoding)
 		free(pEncoding);
 
-	EVP_cleanup();
-	ERR_free_strings();
-
 	return hexfpstr;
 }


### PR DESCRIPTION
Calling EVP_cleanup here undoes initialization already done in lib/fetch
ssl_init causing subsequent attempts to call SSL_CTX_new() to fail.
Which ultimately is the root cause for #170.

Fixes #170 

Maybe moving all LibreSSL initialization/cleanup stuff into xbps_init/end is a good idea?