### PR TITLE
Avoid mmap

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 xbps-0.52 (???):
 
+ * libxbps: avoid mmap in cases where the mmaped file can fill up the address
+   space on 32bit causing out of memory errors. Patches provided by Enno
+   Boland in #183, reported by Christian Neukirchen in #182. See
+   https://github.com/voidlinux/xbps/pull/183 and
+   https://github.com/voidlinux/xbps/pull/182
+
  * xbps-create(1): accept -c/--changelog to set the changelog property of the
    package
 

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -1796,6 +1796,17 @@ bool xbps_mmap_file(const char *file, void **mmf, size_t *mmflen, size_t *filele
 char *xbps_file_hash(const char *file);
 
 /**
+ * Returns a raw byte buffer with the sha256 hash for the file specified
+ * by \a file.
+ *
+ * @param[in] file Path to a file.
+ * @return A pointer to a malloc(3)ed buffer, NULL otherwise and errno
+ * is set appropiately. The pointer should be free(3)d when it's no
+ * longer needed.
+ */
+unsigned char *xbps_file_hash_raw(const char *file);
+
+/**
  * Compares the sha256 hash of the file \a file with the sha256
  * string specified by \a sha256.
  *

--- a/lib/util_hash.c
+++ b/lib/util_hash.c
@@ -132,17 +132,18 @@ xbps_file_hash_raw(const char *file)
 char *
 xbps_file_hash(const char *file)
 {
-	char *res, hash[SHA256_DIGEST_LENGTH * 2 + 1];
+	char *hash;
 	unsigned char *digest;
 
 	if (!(digest = xbps_file_hash_raw(file)))
 		return NULL;
 
+	hash = malloc(SHA256_DIGEST_LENGTH * 2 + 1);
+	assert(hash);
 	digest2string(digest, hash, SHA256_DIGEST_LENGTH);
-	res = strdup(hash);
 	free(digest);
 
-	return res;
+	return hash;
 }
 
 int

--- a/lib/util_hash.c
+++ b/lib/util_hash.c
@@ -125,6 +125,8 @@ xbps_file_hash_raw(const char *file)
 		SHA256_Update(&sha256, buf, len);
 	SHA256_Final(digest, &sha256);
 	close(fd);
+	if(len < 0)
+		return NULL;
 
 	return digest;
 }

--- a/lib/util_hash.c
+++ b/lib/util_hash.c
@@ -123,10 +123,12 @@ xbps_file_hash_raw(const char *file)
 	SHA256_Init(&sha256);
 	while ((len = read(fd, buf, sizeof(buf))) > 0)
 		SHA256_Update(&sha256, buf, len);
+	if(len < 0) {
+		free(digest);
+		return NULL;
+	}
 	SHA256_Final(digest, &sha256);
 	(void)close(fd);
-	if(len < 0)
-		return NULL;
 
 	return digest;
 }

--- a/lib/util_hash.c
+++ b/lib/util_hash.c
@@ -124,7 +124,7 @@ xbps_file_hash_raw(const char *file)
 	while ((len = read(fd, buf, sizeof(buf))) > 0)
 		SHA256_Update(&sha256, buf, len);
 	SHA256_Final(digest, &sha256);
-	close(fd);
+	(void)close(fd);
 	if(len < 0)
 		return NULL;
 


### PR DESCRIPTION
fixes #182

I left mmap for the *.sig files in which I consider safe.