### PR TITLE
Change free space message to avoid ambiguity.

### DIFF
--- a/bin/xbps-install/transaction.c
+++ b/bin/xbps-install/transaction.c
@@ -211,7 +211,7 @@ show_transaction_sizes(struct transaction *trans, int cols)
 			    "%s\n", strerror(errno));
 			return -1;
 		}
-		printf("Free space on disk:           %6s\n", size);
+		printf("Space available on disk:           %6s\n", size);
 	}
 	printf("\n");
 


### PR DESCRIPTION
`xbps-install` will report free space available on disk wording:

> Free space on disk: ...

'free' above is supposed to be  an adjective.
But 'free' can also be a verb,
thus the above message can be interpreted as free some space on disk.

'Free' is now changed to 'Available' to avoid ambiguity.

---
 bin/xbps-install/transaction.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
