### PR TITLE
xbps-remove: fix --dry-run for --clean-cache

### DIFF
--- a/bin/xbps-remove/defs.h
+++ b/bin/xbps-remove/defs.h
@@ -27,6 +27,6 @@
 #define _XBPS_REMOVE_DEFS_H_
 
 /* From clean-cache.c */
-int	clean_cachedir(struct xbps_handle *);
+int	clean_cachedir(struct xbps_handle *, bool drun);
 
 #endif /* !_XBPS_REMOVE_DEFS_H_ */

--- a/bin/xbps-remove/main.c
+++ b/bin/xbps-remove/main.c
@@ -262,7 +262,7 @@ main(int argc, char **argv)
 	maxcols = get_maxcols();
 
 	if (clean_cache) {
-		rv = clean_cachedir(&xh);
+		rv = clean_cachedir(&xh, drun);
 		if (!orphans || rv)
 			exit(rv);;
 	}


### PR DESCRIPTION
`xbps-remove --clean-cache --dry-run` did not consider the
--dry-run flag, this has been fixed.

Fixes #165.