### PR TITLE
xbps-uchroot: umount chroot mounts

### DIFF
--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -349,7 +349,7 @@ main(int argc, char **argv)
 	container_flags = clone_flags & ~(CLONE_NEWNS|CLONE_NEWIPC|CLONE_NEWUTS|CLONE_NEWPID);
 
 	/* Issue the clone(2) syscall with our settings */
-	if ((child = syscall(__NR_clone, clone_flags, NULL)) == -1 ||
+	if ((child = syscall(__NR_clone, clone_flags, NULL)) == -1 &&
 			(child = syscall(__NR_clone, container_flags, NULL)) == -1)
 		die("clone");
 

--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -364,6 +364,13 @@ main(int argc, char **argv)
 			SECBIT_NOROOT|SECBIT_NOROOT_LOCKED) == -1) {
 			die("prctl SECBIT_NOROOT");
 		}
+
+		/* mount as private, systemd mounts it as shared by default */
+		if (mount(NULL, "/", "none", MS_PRIVATE|MS_REC, NULL) == -1)
+			die("Failed to mount / private");
+		if (mount(NULL, "/", "none", MS_PRIVATE|MS_REMOUNT|MS_NOSUID, NULL) == -1)
+			die("Failed to remount /");
+
 		/* setup our overlayfs if set */
 		if (overlayfs)
 			chrootdir = setup_overlayfs(chrootdir, ruid, rgid,


### PR DESCRIPTION
This should fix the issue mentioned by @ebfe in #152.
I'm not sure if there should be error checks or maybe a more smart way to umount relative paths and chroot to avoid all the snprintf calls.
