### PR TITLE
fix some some memory leaks

### DIFF
--- a/lib/package_configure.c
+++ b/lib/package_configure.c
@@ -111,11 +111,11 @@ xbps_configure_pkg(struct xbps_handle *xhp,
 		free(pkgname);
 		return ENOENT;
 	}
+	free(pkgname);
 
 	rv = xbps_pkg_state_dictionary(pkgd, &state);
 	xbps_dbg_printf(xhp, "%s: state %d rv %d\n", pkgver, state, rv);
 	if (rv != 0) {
-		free(pkgname);
 		xbps_dbg_printf(xhp, "%s: [configure] failed to get "
 		    "pkg state: %s\n", pkgver, strerror(rv));
 		return EINVAL;
@@ -124,11 +124,9 @@ xbps_configure_pkg(struct xbps_handle *xhp,
 	if (check_state) {
 		if (state == XBPS_PKG_STATE_INSTALLED) {
 			if ((xhp->flags & XBPS_FLAG_FORCE_CONFIGURE) == 0) {
-				free(pkgname);
 				return 0;
 			}
 		} else if (state != XBPS_PKG_STATE_UNPACKED) {
-			free(pkgname);
 			return EINVAL;
 		}
 	}

--- a/lib/package_unpack.c
+++ b/lib/package_unpack.c
@@ -505,6 +505,7 @@ unpack_archive(struct xbps_handle *xhp,
 		    0, pkgver, "%s: removed obsolete entry: %s", pkgver, file);
 		xbps_object_release(obj);
 	}
+	/* XXX: cant free obsoletes here, need to copy values before */
 	xbps_object_release(pkg_filesd);
 out:
 	/*

--- a/lib/transaction_shlibs.c
+++ b/lib/transaction_shlibs.c
@@ -132,6 +132,7 @@ collect_shlibs(struct xbps_handle *xhp, xbps_array_t pkgs, bool req)
 		}
 	}
 	xbps_object_iterator_release(iter);
+	xbps_object_release(pd);
 	return d;
 }
 
@@ -176,6 +177,7 @@ xbps_transaction_shlibs(struct xbps_handle *xhp, xbps_array_t pkgs, xbps_array_t
 		xbps_object_release(array);
 	}
 	xbps_object_iterator_release(iter);
+	/* XXX: not possible to free shrequires without copying values */
 	xbps_object_release(shprovides);
 
 	return unmatched;


### PR DESCRIPTION
This fixes a few memory leaks I found by running xbps-\* commands in the test suite with valgrind.
There are a few more but they are not that easy to fix, I added two comments where I tried to fix it but failed because it uses the values in some other functions and therefor segfaults later if its freed.

```
sed -i -e 's|xbps-|valgrind --leak-check=full --track-origins=yes --log-file=/home/duncan/repos/xbps/logs/%p.log xbps-|g' tests/xbps/*/*.sh
```
