### PR TITLE
xbps-uchroot and xbps-uunshare usability improvements

### DIFF
--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -319,6 +319,14 @@ main(int argc, char **argv)
 	if (strcmp(chrootdir, "/") == 0)
 		die("/ is not allowed to be used as chrootdir");
 
+	/* Make chrootdir absolute */
+	if (chrootdir[0] != '/') {
+		char cwd[PATH_MAX-1];
+		if (getcwd(cwd, sizeof(cwd)) == NULL)
+			die("getcwd");
+		chrootdir = xbps_xasprintf("%s/%s", cwd, chrootdir);
+	}
+
 	if (getresgid(&rgid, &egid, &sgid) == -1)
 		die("getresgid");
 

--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -281,7 +281,7 @@ main(int argc, char **argv)
 	tmpfs_opts = chrootdir = cmd = NULL;
 	argv0 = argv[0];
 
-	while ((c = getopt_long(argc, argv, "Oto:b:V", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "+Oto:b:V", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'O':
 			overlayfs = true;

--- a/bin/xbps-uunshare/main.c
+++ b/bin/xbps-uunshare/main.c
@@ -157,13 +157,21 @@ main(int argc, char **argv)
 	if (argc < 2)
 		usage(argv0);
 
-	chrootdir = argv[0];
+	chrootdir = argv[-1];
 	cmd = argv[1];
 	cmdargs = argv + 1;
 
 	/* Never allow chrootdir == / */
 	if (strcmp(chrootdir, "/") == 0)
 		die("/ is not allowed to be used as chrootdir");
+
+	/* Make chrootdir absolute */
+	if (chrootdir[0] != '/') {
+		char cwd[PATH_MAX-1];
+		if (getcwd(cwd, sizeof(cwd)) == NULL)
+			die("getcwd");
+		chrootdir = xbps_xasprintf("%s/%s", cwd, chrootdir);
+	}
 
 	/*
 	 * Unshare from the current process namespaces and set ours.

--- a/bin/xbps-uunshare/main.c
+++ b/bin/xbps-uunshare/main.c
@@ -136,7 +136,7 @@ main(int argc, char **argv)
 	chrootdir = cmd = NULL;
 	argv0 = argv[0];
 
-	while ((c = getopt_long(argc, argv, "b:V", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "+b:V", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'b':
 			if (optarg == NULL || *optarg == '\0')


### PR DESCRIPTION
This fixes #203 and #204 for `xbps-uchroot` and `xbps-uunshare`.
Not sure if it should support `.` to use the current directory as chrootdir and if there should be more error checks to make sure the chrootdir exists.
