### PR TITLE
xbps-checkvers.1: fix incorrect double negative

### DIFF
--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -16,7 +16,7 @@ the source package versions available in a
 .Nm void-packages
 tree. By default and unless the
 .Fl i, Fl -installed
-option is not set, it will compare package versions in repositories against
+option is set, it will compare package versions in repositories against
 the
 .Nm void-packages
 tree. The


### PR DESCRIPTION
unless ... not set <=> except if (... not set), which makes no sense here.