### PR TITLE
Fix pkgdb and files plist permissions with restictive umask.

### DIFF
--- a/lib/package_unpack.c
+++ b/lib/package_unpack.c
@@ -461,15 +461,19 @@ unpack_archive(struct xbps_handle *xhp,
 	 * Externalize binpkg files.plist to disk, if not empty.
 	 */
 	if (xbps_dictionary_count(binpkg_filesd)) {
+		mode_t prev_umask;
+		prev_umask = umask(022);
 		buf = xbps_xasprintf("%s/.%s-files.plist", xhp->metadir, pkgname);
 		if (!xbps_dictionary_externalize_to_file(binpkg_filesd, buf)) {
 			rv = errno;
+			umask(prev_umask);
 			free(buf);
 			xbps_set_cb_state(xhp, XBPS_STATE_UNPACK_FAIL,
 			    rv, pkgver, "%s: [unpack] failed to externalize pkg "
 			    "pkg metadata files: %s", pkgver, strerror(rv));
 			goto out;
 		}
+		umask(prev_umask);
 		free(buf);
 	}
 	/*

--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -216,6 +216,7 @@ int
 xbps_pkgdb_update(struct xbps_handle *xhp, bool flush, bool update)
 {
 	xbps_dictionary_t pkgdb_storage;
+	mode_t prev_umask;
 	static int cached_rv;
 	int rv = 0;
 
@@ -227,8 +228,12 @@ xbps_pkgdb_update(struct xbps_handle *xhp, bool flush, bool update)
 		if (pkgdb_storage == NULL ||
 		    !xbps_dictionary_equals(xhp->pkgdb, pkgdb_storage)) {
 			/* flush dictionary to storage */
-			if (!xbps_dictionary_externalize_to_file(xhp->pkgdb, xhp->pkgdb_plist))
+			prev_umask = umask(022);
+			if (!xbps_dictionary_externalize_to_file(xhp->pkgdb, xhp->pkgdb_plist)) {
+				umask(prev_umask);
 				return errno;
+			}
+			umask(prev_umask);
 		}
 		if (pkgdb_storage)
 			xbps_object_release(pkgdb_storage);

--- a/lib/repo_sync.c
+++ b/lib/repo_sync.c
@@ -74,6 +74,7 @@ xbps_get_remote_repo_string(const char *uri)
 int HIDDEN
 xbps_repo_sync(struct xbps_handle *xhp, const char *uri)
 {
+	mode_t prev_umask;
 	const char *arch, *fetchstr = NULL;
 	char *repodata, *lrepodir, *uri_fixedp;
 	int rv = 0;
@@ -130,6 +131,7 @@ xbps_repo_sync(struct xbps_handle *xhp, const char *uri)
 	/*
 	 * Download plist index file from repository.
 	 */
+	prev_umask = umask(022);
 	if ((rv = xbps_fetch_file(xhp, repodata, NULL)) == -1) {
 		/* reposync error cb */
 		fetchstr = xbps_fetch_error_string();
@@ -139,6 +141,7 @@ xbps_repo_sync(struct xbps_handle *xhp, const char *uri)
 		    repodata, fetchstr ? fetchstr : strerror(errno));
 	} else if (rv == 1)
 		rv = 0;
+	umask(prev_umask);
 
 	free(repodata);
 


### PR DESCRIPTION
`xbps_dictionary_externalize_to_file` uses `_prop_object_externalize_write_file` [1] which creates a new file, sets the permissions with `fchmod(fd, 0666 & ~myumask)` and then renames the new file to the original filename which then ends up with wrong permissions if the umask is too restrictive.

This should fix #232 and #213.

[1] https://github.com/voidlinux/xbps/blob/0.51/lib/portableproplib/prop_object.c#L816