### PR TITLE
configure: fix vasprintf test

### DIFF
--- a/configure
+++ b/configure
@@ -390,7 +390,8 @@ else
 #define _GNU_SOURCE
 #include <stdio.h>
 int main(void) {
-	vasprintf(NULL, NULL, NULL);
+	va_list ap;
+	vasprintf(NULL, NULL, ap);
 	return 0;
 }
 EOF


### PR DESCRIPTION
Fix the test for vasprintf function which failed with musl libc and
fortify-headers on aarch64:

````
_vasprintf.c:4:24: error: incompatible type for argument 3 of 'vasprintf'
  vasprintf(NULL, NULL, NULL);
                        ^~~~
````