### PR TITLE
manpages: fix invalid escape

### DIFF
--- a/bin/xbps-alternatives/xbps-alternatives.1
+++ b/bin/xbps-alternatives/xbps-alternatives.1
@@ -23,7 +23,7 @@ alternative groups registered previously, the previous package is set as default
 .Bl -tag -width -x
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl d, Fl -debug
 Enables extra debugging shown to stderr.

--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -26,7 +26,7 @@ argument sets extra packages to process with the outdated ones (only processed i
 .Bl -tag -width -x
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl D, Fl -distdir Ar dir
 Specifies a full path to the void-packages repository. By default set to

--- a/bin/xbps-dgraph/xbps-dgraph.1
+++ b/bin/xbps-dgraph/xbps-dgraph.1
@@ -58,7 +58,7 @@ The first repository matching the package expression wins.
 .Bl -tag -width -x
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl c, Fl -graph-config Ar file
 Specifies a path to the graph configuration file, to modify the settings

--- a/bin/xbps-install/xbps-install.1
+++ b/bin/xbps-install/xbps-install.1
@@ -62,11 +62,11 @@ if no package is depending on it directly.
 .No See Fl -mode Sy auto No in Xr xbps-pkgdb 1 .
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl c, Fl -cachedir Ar dir
 Specifies a path to the cache directory, where binary packages are stored.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl d, Fl -debug
 Enables extra debugging shown to stderr.

--- a/bin/xbps-pkgdb/xbps-pkgdb.1
+++ b/bin/xbps-pkgdb/xbps-pkgdb.1
@@ -41,7 +41,7 @@ Updates the pkgdb format to the latest version.
 Process all registered packages, regardless of its state.
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl d, Fl -debug
 Enables extra debugging shown to stderr.

--- a/bin/xbps-query/xbps-query.1
+++ b/bin/xbps-query/xbps-query.1
@@ -55,11 +55,11 @@ The first repository matching the package expression wins.
 .Bl -tag -width -x
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl c, Fl -cachedir Ar dir
 Specifies a path to the cache directory, where binary packages are stored.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl d, Fl -debug
 Enables extra debugging shown to stderr.

--- a/bin/xbps-reconfigure/xbps-reconfigure.1
+++ b/bin/xbps-reconfigure/xbps-reconfigure.1
@@ -37,7 +37,7 @@ option is specified.
 Configures all packages.
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl d, Fl -debug
 Enables extra debugging shown to stderr.

--- a/bin/xbps-remove/xbps-remove.1
+++ b/bin/xbps-remove/xbps-remove.1
@@ -60,11 +60,11 @@ Package is unregistered from package database.
 .Bl -tag -width -x
 .It Fl C, Fl -config Ar dir
 Specifies a path to the XBPS configuration directory.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl c, Fl -cachedir Ar dir
 Specifies a path to the cache directory, where binary packages are stored.
-If the first character is not '\/' then it's a relative path of
+If the first character is not '/' then it's a relative path of
 .Ar rootdir .
 .It Fl d, Fl -debug
 Enables extra debugging shown to stderr.

--- a/data/xbps.d.5
+++ b/data/xbps.d.5
@@ -54,7 +54,7 @@ This will be applied to dependencies as well.
 .It Sy cachedir=path
 Sets the default cache directory to store downloaded binary packages from
 remote repositories, as well as its signatures.
-If path starts with '\/' it's an absolute path, otherwise it will be relative to
+If path starts with '/' it's an absolute path, otherwise it will be relative to
 .Ar rootdir .
 .It Sy include=path/file.conf
 Imports settings from the specified configuration file.


### PR DESCRIPTION
'\\/' renders as '' with mdocml.
