### PR TITLE
[RFC] lib/external/fexec.c: always exec in chroot with uid=0

### DIFF
--- a/lib/external/fexec.c
+++ b/lib/external/fexec.c
@@ -52,11 +52,11 @@ pfcexec(struct xbps_handle *xhp, const char *file, const char **argv)
 	switch (child) {
 	case 0:
 		/*
-		 * If rootdir != / and uid==0 and bin/sh exists,
+		 * If rootdir != / and uid==0,
 		 * change root directory and exec command.
 		 */
 		if (strcmp(xhp->rootdir, "/")) {
-			if ((geteuid() == 0) && (access("bin/sh", X_OK) == 0)) {
+			if (geteuid() == 0) {
 				if (chroot(xhp->rootdir) == -1) {
 					xbps_dbg_printf(xhp, "%s: chroot() "
 					    "failed: %s\n", *argv, strerror(errno));


### PR DESCRIPTION
When installing into a rootdir != '/', INSTALL/REMOVE scripts are
currently only executed inside a chroot if uid=0 _and_ the target
rootdir contains an executable bin/sh. Since INSTALL scripts are
executed twice on installation ("pre" and "post" action), an INSTALL
script ran with uid=0 that does the equivalent of `rm -rf /` will wipe
rootdir on the "pre" stage and wipe the real '/' on the "post" stage
(/bin/sh no longer exists -> no chroot).

This removes the check for /bin/sh resulting in always running the
script in a chroot. At least in the uid=0 case.