### PR TITLE
Fix compilation errors on GCC 7

### DIFF
--- a/bin/xbps-install/fetch_cb.c
+++ b/bin/xbps-install/fetch_cb.c
@@ -65,7 +65,7 @@ static const char *
 stat_eta(const struct xbps_fetch_cb_data *xfpd, void *cbdata)
 {
 	struct xferstat *xfer = cbdata;
-	static char str[16];
+	static char str[25];
 	long elapsed, eta;
 	off_t received, expected;
 

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -592,7 +592,7 @@ struct xbps_handle {
 	 *
 	 * Full path to the xbps configuration directory.
 	 */
-	char confdir[XBPS_MAXPATH];
+	char confdir[XBPS_MAXPATH+sizeof(XBPS_SYSCONF_PATH)];
 	/**
 	 * @var rootdir
 	 *
@@ -606,14 +606,14 @@ struct xbps_handle {
 	 * Cache directory to store downloaded binary packages.
 	 * If unset, defaults to \a XBPS_CACHE_PATH (relative to rootdir).
 	 */
-	char cachedir[XBPS_MAXPATH];
+	char cachedir[XBPS_MAXPATH+sizeof(XBPS_CACHE_PATH)];
 	/**
 	 * @var metadir
 	 *
 	 * Metadata directory for all operations in XBPS.
 	 * If unset, defaults to \a XBPS_CACHE_PATH (relative to rootdir).
 	 */
-	char metadir[XBPS_MAXPATH];
+	char metadir[XBPS_MAXPATH+sizeof(XBPS_META_PATH)];
 	/**
 	 * @var native_arch
 	 *

--- a/lib/fetch/ftp.c
+++ b/lib/fetch/ftp.c
@@ -339,7 +339,7 @@ ftp_cwd(conn_t *conn, const char *path, int subdir)
 		len = strlen(pwd);
 
 		/* Look for a common prefix between PWD and dir to fetch. */
-		for (i = 0; i <= len && i <= end - dst; ++i)
+		for (i = 0; i < len && i < end - dst; ++i)
 			if (pwd[i] != dst[i])
 				break;
 		/* Keep going up a dir until we have a matching prefix. */
@@ -440,10 +440,6 @@ ftp_mode_type(conn_t *conn, int mode, int type)
 		type = 'A';
 	case 'A':
 		break;
-	case 'd':
-		type = 'D';
-	case 'D':
-		/* can't handle yet */
 	default:
 		return (FTP_PROTOCOL_ERROR);
 	}

--- a/lib/initend.c
+++ b/lib/initend.c
@@ -397,7 +397,7 @@ int
 xbps_init(struct xbps_handle *xhp)
 {
 	struct utsname un;
-	char cwd[PATH_MAX-1], sysconfdir[XBPS_MAXPATH], *buf;
+	char cwd[PATH_MAX-1], sysconfdir[XBPS_MAXPATH+sizeof(XBPS_SYSDEFCONF_PATH)], *buf;
 	const char *repodir, *native_arch;
 	int rv;
 


### PR DESCRIPTION
I know it's mentioned in the README that it was tested on GCC 4.X, but I was curious if it would run on GCC 7 and it didn't :).

I went over the problems the compiler found and tried to solve them. They weren't that many, but some of them were a little bit tricky.

I think some of them are valid complains and possible bugs, but my work here was very naive: With little context of the project as a whole I tried to fix what I saw. I'm sure I missed something in the process, so excuse me in advance for that.

I separated every file in one commit in which I tried to explain the context of it.

Here is the version of my compiler:

```
$ gcc --version
gcc (GCC) 7.1.1 20170630
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```