### PR TITLE
Allow no disk space check

### DIFF
--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -146,6 +146,10 @@ main(int argc, char **argv)
 			fflag++;
 			if (fflag > 1)
 				flags |= XBPS_FLAG_FORCE_UNPACK;
+
+			if (fflag > 2)
+				flags |= XBPS_FLAG_SKIP_SPACE_CHECK;
+
 			reinstall = true;
 			break;
 		case 'h':

--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -50,6 +50,8 @@ usage(bool fail)
 	    " -f --force               Force package re-installation\n"
 	    "                          If specified twice, all files will be\n"
 	    "                          overwritten.\n"
+	    "                          If specified three times, the check for\n"
+	    "                          enough disk space will be skipped.\n"
 	    " -h --help                Print help usage\n"
 	    " -i --ignore-conf-repos   Ignore repositories defined in xbps.d\n"
 	    " -U --unpack-only         Unpack packages in transaction, do not configure them\n"

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -208,6 +208,14 @@
 #define XBPS_FLAG_UNPACK_ONLY 		0x00001000
 
 /**
+ * @def XBPS_FLAG_SKIP_SPACE_CHECK
+ * Do not check for disk space. Package will be installed
+ * unconditionally.
+ * Must be set through the xbps_handle::flags member.
+ */
+#define XBPS_FLAG_SKIP_SPACE_CHECK	0x00002000
+
+/**
  * @def XBPS_FETCH_CACHECONN
  * Default (global) limit of cached connections used in libfetch.
  */

--- a/lib/transaction_dictionary.c
+++ b/lib/transaction_dictionary.c
@@ -167,20 +167,22 @@ compute_transaction_stats(struct xbps_handle *xhp)
 				"total-removed-size", rmsize))
 		return EINVAL;
 
-	/* Get free space from target rootdir: return ENOSPC if there's not enough space */
-	if (statvfs(xhp->rootdir, &svfs) == -1) {
-		xbps_dbg_printf(xhp, "%s: statvfs failed: %s\n", __func__, strerror(errno));
-		return 0;
+	if (!(xhp->flags & XBPS_FLAG_SKIP_SPACE_CHECK)) {
+		/* Get free space from target rootdir: return ENOSPC if there's not enough space */
+		if (statvfs(xhp->rootdir, &svfs) == -1) {
+			xbps_dbg_printf(xhp, "%s: statvfs failed: %s\n", __func__, strerror(errno));
+			return 0;
+		}
+		/* compute free space on disk */
+		rootdir_free_size = svfs.f_bfree * svfs.f_bsize;
+
+		if (!xbps_dictionary_set_uint64(xhp->transd,
+					"disk-free-size", rootdir_free_size))
+			return EINVAL;
+
+		if (instsize > rootdir_free_size)
+			return ENOSPC;
 	}
-	/* compute free space on disk */
-	rootdir_free_size = svfs.f_bfree * svfs.f_bsize;
-
-	if (!xbps_dictionary_set_uint64(xhp->transd,
-				"disk-free-size", rootdir_free_size))
-		return EINVAL;
-
-	if (instsize > rootdir_free_size)
-		return ENOSPC;
 
 	return 0;
 }


### PR DESCRIPTION
Skip disk space check when force flag is used three times, e.g.

    xbps-install -f -f -f <very large package>