### PR TITLE
Consistently use pkg-config to find libssl and document the versions required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To build this you'll need:
   - [GNU make](http://www.gnu.org/software/make/)
   - [pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config/)
   - [zlib](http://www.zlib.net)
-  - [openssl](http://www.openssl.org)
+  - [openssl < 1.1](http://www.openssl.org) or [libressl](https://www.libressl.org/)
   - [libarchive >= 3.2.0](http://www.libarchive.org)
 
 and optionally:

--- a/configure
+++ b/configure
@@ -675,43 +675,21 @@ else
 fi
 
 #
-# OpenSSL libssl with pkg-config support is required when building
-# the static binaries.
+# libssl with pkg-config support is required.
 #
-if [ "$BUILD_STATIC" = "yes" ]; then
-	printf "Checking for OpenSSL via pkg-config ... "
-	if ! $PKGCONFIG_BIN --exists libssl; then
-		echo "libssl.pc file not found, exiting."
-		exit 1
-	else
-		echo "found version $($PKGCONFIG_BIN --modversion libssl)."
-		echo "CFLAGS += $($PKGCONFIG_BIN --cflags libssl)" >>$CONFIG_MK
-		echo "LDFLAGS +=        $($PKGCONFIG_BIN --libs libssl)" >>$CONFIG_MK
-		echo "STATIC_LIBS +=    $($PKGCONFIG_BIN --libs --static libssl)" \
-			>>$CONFIG_MK
-	fi
+printf "Checking for libssl via pkg-config ... "
+if $PKGCONFIG_BIN --exists 'libssl < 1.1' && ! $PKGCONFIG_BIN --exists libtls ; then
+	echo "found OpenSSL version $($PKGCONFIG_BIN --modversion libssl)."
+elif $PKGCONFIG_BIN --exists libssl libtls; then
+	echo "found LibreSSL version $($PKGCONFIG_BIN --modversion libssl)."
 else
-	func=SHA256
-	printf "Checking for OpenSSL $func() ... "
-cat <<EOF > _$func.c
-#include <openssl/sha.h>
-int main(void) {
-	SHA256(NULL, NULL, 0);
-	return 0;
-}
-EOF
-	if $XCC _$func.c -lcrypto -o _$func 2>/dev/null; then
-		echo yes.
-		echo "LDFLAGS +=	-lcrypto" >>$CONFIG_MK
-	else
-		CRYPTO_SHA256=no
-	fi
-	rm -f _$func.c _$func
-	if [ "$CRYPTO_SHA256" = "no" ]; then
-		echo "Failed to link with your system's OpenSSL library, can't continue..."
-		exit 1
-	fi
+	echo "libssl.pc file not found or incompatible version detected, exiting."
+	exit 1
 fi
+echo "CFLAGS += $($PKGCONFIG_BIN --cflags libssl)" >>$CONFIG_MK
+echo "LDFLAGS +=        $($PKGCONFIG_BIN --libs libssl)" >>$CONFIG_MK
+echo "STATIC_LIBS +=    $($PKGCONFIG_BIN --libs --static libssl)" \
+	>>$CONFIG_MK
 
 #
 # If --enable-static enabled, build static binaries.


### PR DESCRIPTION
xbps is available in the Arch User Repository, but it doesn't build because it is incompatible with openssl 1.1

(It also doesn't build because of using -Werror in production code as part of "stable" releases instead of via CFLAGS on Travis, but that is another story.)

The standard way to fix this is to rely on pkg-config so that users can point PKG_CONFIG_PATH to their openssl-1.0 package or whatever, and fortunately that results in fewer lines of code that is also more robust. :smile:

Fixes #263, you can update the version requirements whenever xbps is updated to work with openssl 1.1

/cc @Vaelatern 