### PR TITLE
updated urls within documentation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1248,7 +1248,7 @@ xbps-0.21 (2013-03-11):
    compares the whole file list between current and new package. A test has been
    added to the kyua testsuite to test its correctness.
 
- * Imported Portable proplib 0.6.3 from http://code.google.com/p/portableproplib.
+ * Imported Portable proplib 0.6.3 from https://github.com/xtraeme/portableproplib
 
  * xbps-query(1): a full dependency tree can now be shown in the
    show-deps mode, by specifying -x twice (--show-deps), e.g:
@@ -1560,7 +1560,7 @@ xbps-0.16.5 (2012-07-14):
 
 xbps-0.16.4 (2012-07-10):
 
- * Imported proplib 0.6.1 from http://code.google.com/p/portableproplib.
+ * Imported proplib 0.6.1 from https://github.com/xtraeme/portableproplib
 
  * libxbps: when finding obsolete files also match against sha256, not
    just the filename. Also ignore symlinks found in rootfs to make
@@ -1717,7 +1717,7 @@ xbps-0.15 (2012-04-06):
    available in repository pool. Thanks to dave for testing!
 
  * Started a test suite for libxbps. Tests are written for Kyua
-   (http://code.google.com/p/kyua) and can be built and installed
+   (https://github.com/jmmv/kyua) and can be built and installed
    with the --with-tests configure option, by default will be installed
    to EPREFIX/tests but can be overriden with --testsdir. ATF 0.15
    (part of Kyua) is required to build the test suite.
@@ -1949,7 +1949,7 @@ xbps-0.10.1 (2011-10-26):
 xbps-0.10.0 (2011-10-21):
 
  * Fixed issue 11 "xbps-bin fails to update properly some pkgs".
-	http://code.google.com/p/xbps/issues/detail?id=11
+	hxxp://code.google.com/p/xbps/issues/detail?id=11
 
  * xbps-bin(1): the 'check' target now is able to detect if a package
    was installed manually and other packages are currently depending
@@ -1961,13 +1961,13 @@ xbps-0.10.0 (2011-10-21):
    repositories.plist) are stored.
 
  * New configuration scheme for virtual packages as defined in
-	http://code.google.com/p/xbps/issues/detail?id=12
+	hxxp://code.google.com/p/xbps/issues/detail?id=12
 
    XBPS now reads all plist files in PREFIX/etc/xbps/virtualpkg.d.wants
    directory with settings for the wanted virtual packages.
 
  * New configuration scheme as defined in
-	http://code.google.com/p/xbps/issues/detail?id=12
+	hxxp://code.google.com/p/xbps/issues/detail?id=12
 
    A directory to store XBPS configuration files is now used, by default
    set to PREFIX/etc/xbps. Configuration options are now set via

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ and optionally:
 
   - [graphviz](http://www.graphviz.org) and [doxygen](http://www.doxygen.org)
     (--enable-api-docs) to build API documentation.
-  - [atf >= 0.15](http://code.google.com/p/kyua) (--enable-tests) to build the
+  - [atf >= 0.15](https://github.com/jmmv/kyua) (--enable-tests) to build the
     Kyua test suite.
 
 ### Tests

--- a/configure
+++ b/configure
@@ -44,7 +44,7 @@ for instance \`--prefix=\$HOME'.
 --enable-fulldebug	Enables extra debugging code (default disabled)
 --enable-static 	Build XBPS static utils (default disabled)
 --enable-tests		Build and install Kyua tests (default disabled)
-			Needs atf >= 0.15 (http://code.google.com/p/kyua)
+			Needs atf >= 0.15 (https://github.com/jmmv/kyua)
 _EOF
 	exit 1
 }

--- a/doc/xbps_pkg_props_dictionary.dot
+++ b/doc/xbps_pkg_props_dictionary.dot
@@ -7,7 +7,7 @@ digraph pkg_props_dictionary {
 	main [label="Package dictionary"];
 	main -> homepage [label="string"];
 	homepage -> homepage_value;
-	homepage_value [style=filled,fillcolor="yellowgreen",label="http://code.google.com/p/xbps"];
+	homepage_value [style=filled,fillcolor="yellowgreen",label="https://github.com/voidlinux/xbps"];
 	main -> license [label="string"];
 	license -> license_value;
 	license_value [style=filled,fillcolor="yellowgreen",label="BSD"];


### PR DESCRIPTION
because "code.google.com" is defunct