### PR TITLE
libxbps: detection of orphaned packages is now 86% faster.

### DIFF
--- a/tests/xbps/libxbps/find_pkg_orphans/main.c
+++ b/tests/xbps/libxbps/find_pkg_orphans/main.c
@@ -30,22 +30,22 @@ static const char expected_output[] =
 	"xbps-git-20130310_2\n"
 	"xbps-triggers-1.0_1\n"
 	"libxbps-git-20130310_2\n"
-	"confuse-2.7_2\n"
 	"proplib-0.6.3_1\n"
 	"libarchive-3.1.2_1\n"
 	"libfetch-2.34_1\n"
-	"bzip2-1.0.5_1\n"
-	"liblzma-5.0.4_3\n"
-	"expat-2.1.0_3\n"
-	"attr-2.4.46_5\n"
+	"confuse-2.7_2\n"
 	"libssl-1.0.1e_3\n"
 	"zlib-1.2.7_1\n"
+	"attr-2.4.46_5\n"
+	"expat-2.1.0_3\n"
+	"liblzma-5.0.4_3\n"
+	"bzip2-1.0.5_1\n"
 	"glibc-2.20_1\n";
 
 static const char expected_output_all[] =
 	"unexistent-pkg-0_1\n"
-	"orphan1-0_1\n"
-	"orphan0-0_1\n";
+	"orphan0-0_1\n"
+	"orphan1-0_1\n";
 
 ATF_TC(find_pkg_orphans_test);
 ATF_TC_HEAD(find_pkg_orphans_test, tc)


### PR DESCRIPTION
## Profit
On my hardware, time of processing [meta-type package with dependecies of marble5](https://github.com/Chocimier/void-packages/blob/autoremove-benchmark/srcpkgs/autoremove-benchmark/template) reduce by 7 times, and most of that reduced time is installing dependencies.

## How does it work?

Instead of building deptree, then checking its all components, list of packages to remove (`array`) is used as queue for BFS graph traversing. Speedup comes from the fact, that if some package is still needed, all its sub-deptree can't be removed too, and processing that sub-tree is futile.
The other change is early exit from revdeps loop. When one revdep of X package is not orphan, it is clear that X is not orpan too.
Changes in test does only update order in which packages are selected for removal.

## The catch

Above example shows some strange thing: `libcolord` run_depends do not contain `eudev-libudev`, but `eudev-libudev`'s revdeps contain `libcolord`. In effect `eudev-libudev` happens to not be removed. Is it a typical case I should care for?

---

Related to #270