### PR TITLE
fix namespace violation (#291)

### DIFF
--- a/bin/xbps-alternatives/main.c
+++ b/bin/xbps-alternatives/main.c
@@ -55,7 +55,7 @@ usage(bool fail)
 }
 
 static int
-state_cb(const struct xbps_state_cb_data *xscd, void *cbd _unused)
+state_cb(const struct xbps_state_cb_data *xscd, void *cbd UNUSED)
 {
 	bool slog = false;
 

--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -187,7 +187,7 @@ process_one_alternative(const char *altgrname, const char *val)
 
 
 static void
-process_dict_of_arrays(const char *key _unused, const char *val)
+process_dict_of_arrays(const char *key UNUSED, const char *val)
 {
 	char *altgrname, *args, *p, *saveptr;
 
@@ -290,7 +290,7 @@ entry_is_conf_file(const char *file)
 }
 
 static int
-ftw_cb(const char *fpath, const struct stat *sb, int type, struct FTW *ftwbuf _unused)
+ftw_cb(const char *fpath, const struct stat *sb, int type, struct FTW *ftwbuf UNUSED)
 {
 	xbps_dictionary_t fileinfo = NULL;
 	const char *filep = NULL;

--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -68,7 +68,7 @@ usage(bool fail)
 }
 
 static void
-unpack_progress_cb(const struct xbps_unpack_cb_data *xpd, void *cbdata _unused)
+unpack_progress_cb(const struct xbps_unpack_cb_data *xpd, void *cbdata UNUSED)
 {
 	if (xpd->entry == NULL || xpd->entry_total_count <= 0)
 		return;
@@ -80,7 +80,7 @@ unpack_progress_cb(const struct xbps_unpack_cb_data *xpd, void *cbdata _unused)
 }
 
 static int
-repo_import_key_cb(struct xbps_repo *repo, void *arg _unused, bool *done _unused)
+repo_import_key_cb(struct xbps_repo *repo, void *arg UNUSED, bool *done UNUSED)
 {
 	int rv;
 

--- a/bin/xbps-install/state_cb.c
+++ b/bin/xbps-install/state_cb.c
@@ -32,7 +32,7 @@
 #include "defs.h"
 
 int
-state_cb(const struct xbps_state_cb_data *xscd, void *cbdata _unused)
+state_cb(const struct xbps_state_cb_data *xscd, void *cbdata UNUSED)
 {
 	xbps_dictionary_t pkgd;
 	const char *instver, *newver;

--- a/bin/xbps-pkgdb/check.c
+++ b/bin/xbps-pkgdb/check.c
@@ -36,11 +36,11 @@
 #include "defs.h"
 
 static int
-pkgdb_cb(struct xbps_handle *xhp _unused,
+pkgdb_cb(struct xbps_handle *xhp UNUSED,
 		xbps_object_t obj,
-		const char *key _unused,
+		const char *key UNUSED,
 		void *arg,
-		bool *done _unused)
+		bool *done UNUSED)
 {
 	const char *pkgver;
 	char *pkgname;

--- a/bin/xbps-pkgdb/check_pkg_unneeded.c
+++ b/bin/xbps-pkgdb/check_pkg_unneeded.c
@@ -43,7 +43,7 @@
  * 	  and remove them if that was true.
  */
 int
-check_pkg_unneeded(struct xbps_handle *xhp _unused, const char *pkgname, void *arg)
+check_pkg_unneeded(struct xbps_handle *xhp UNUSED, const char *pkgname, void *arg)
 {
 	xbps_array_t replaces;
 	xbps_dictionary_t pkgd = arg;

--- a/bin/xbps-query/list.c
+++ b/bin/xbps-query/list.c
@@ -38,11 +38,11 @@ struct list_pkgver_cb {
 };
 
 int
-list_pkgs_in_dict(struct xbps_handle *xhp _unused,
+list_pkgs_in_dict(struct xbps_handle *xhp UNUSED,
 		  xbps_object_t obj,
-		  const char *key _unused,
+		  const char *key UNUSED,
 		  void *arg,
-		  bool *loop_done _unused)
+		  bool *loop_done UNUSED)
 {
 	struct list_pkgver_cb *lpc = arg;
 	const char *pkgver, *short_desc, *state_str;
@@ -88,11 +88,11 @@ list_pkgs_in_dict(struct xbps_handle *xhp _unused,
 }
 
 int
-list_manual_pkgs(struct xbps_handle *xhp _unused,
+list_manual_pkgs(struct xbps_handle *xhp UNUSED,
 		 xbps_object_t obj,
-		 const char *key _unused,
-		 void *arg _unused,
-		 bool *loop_done _unused)
+		 const char *key UNUSED,
+		 void *arg UNUSED,
+		 bool *loop_done UNUSED)
 {
 	const char *pkgver;
 	bool automatic = false;
@@ -107,11 +107,11 @@ list_manual_pkgs(struct xbps_handle *xhp _unused,
 }
 
 int
-list_hold_pkgs(struct xbps_handle *xhp _unused,
+list_hold_pkgs(struct xbps_handle *xhp UNUSED,
 		xbps_object_t obj,
-		const char *key _unused,
-		void *arg _unused,
-		bool *loop_done _unused)
+		const char *key UNUSED,
+		void *arg UNUSED,
+		bool *loop_done UNUSED)
 {
 	const char *pkgver;
 
@@ -124,11 +124,11 @@ list_hold_pkgs(struct xbps_handle *xhp _unused,
 }
 
 int
-list_repolock_pkgs(struct xbps_handle *xhp _unused,
+list_repolock_pkgs(struct xbps_handle *xhp UNUSED,
 		xbps_object_t obj,
-		const char *key _unused,
-		void *arg _unused,
-		bool *loop_done _unused)
+		const char *key UNUSED,
+		void *arg UNUSED,
+		bool *loop_done UNUSED)
 {
 	const char *pkgver;
 
@@ -171,7 +171,7 @@ list_pkgs_pkgdb(struct xbps_handle *xhp)
 }
 
 static int
-repo_list_uri_cb(struct xbps_repo *repo, void *arg _unused, bool *done _unused)
+repo_list_uri_cb(struct xbps_repo *repo, void *arg UNUSED, bool *done UNUSED)
 {
 	const char *signedby = NULL;
 	uint16_t pubkeysize = 0;
@@ -219,11 +219,11 @@ struct fflongest {
 };
 
 static int
-_find_longest_pkgver_cb(struct xbps_handle *xhp _unused,
+_find_longest_pkgver_cb(struct xbps_handle *xhp UNUSED,
 			xbps_object_t obj,
-			const char *key _unused,
+			const char *key UNUSED,
 			void *arg,
-			bool *loop_done _unused)
+			bool *loop_done UNUSED)
 {
 	struct fflongest *ffl = arg;
 	const char *pkgver;

--- a/bin/xbps-query/ownedby.c
+++ b/bin/xbps-query/ownedby.c
@@ -97,9 +97,9 @@ match_files_by_pattern(xbps_dictionary_t pkg_filesd,
 static int
 ownedby_pkgdb_cb(struct xbps_handle *xhp,
 		xbps_object_t obj,
-		const char *obj_key _unused,
+		const char *obj_key UNUSED,
 		void *arg,
-		bool *done _unused)
+		bool *done UNUSED)
 {
 	xbps_dictionary_t pkgmetad;
 	xbps_array_t files_keys;
@@ -129,9 +129,9 @@ ownedby_pkgdb_cb(struct xbps_handle *xhp,
 static int
 repo_match_cb(struct xbps_handle *xhp,
 		xbps_object_t obj,
-		const char *key _unused,
+		const char *key UNUSED,
 		void *arg,
-		bool *done _unused)
+		bool *done UNUSED)
 {
 	xbps_dictionary_t filesd;
 	xbps_array_t files_keys;
@@ -163,7 +163,7 @@ repo_match_cb(struct xbps_handle *xhp,
 }
 
 static int
-repo_ownedby_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
+repo_ownedby_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
 {
 	xbps_array_t allkeys;
 	struct ffdata *ffd = arg;

--- a/bin/xbps-query/search.c
+++ b/bin/xbps-query/search.c
@@ -94,11 +94,11 @@ print_results(struct xbps_handle *xhp, struct search_data *sd)
 }
 
 static int
-search_array_cb(struct xbps_handle *xhp _unused,
+search_array_cb(struct xbps_handle *xhp UNUSED,
 		xbps_object_t obj,
-		const char *key _unused,
+		const char *key UNUSED,
 		void *arg,
-		bool *done _unused)
+		bool *done UNUSED)
 {
 	xbps_object_t obj2;
 	struct search_data *sd = arg;
@@ -210,7 +210,7 @@ search_array_cb(struct xbps_handle *xhp _unused,
 }
 
 static int
-search_repo_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
+search_repo_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
 {
 	xbps_array_t allkeys;
 	struct search_data *sd = arg;

--- a/bin/xbps-reconfigure/main.c
+++ b/bin/xbps-reconfigure/main.c
@@ -52,7 +52,7 @@ usage(bool fail)
 }
 
 static int
-state_cb(const struct xbps_state_cb_data *xscd, void *cbd _unused)
+state_cb(const struct xbps_state_cb_data *xscd, void *cbd UNUSED)
 {
 	bool slog = false;
 

--- a/bin/xbps-remove/clean-cache.c
+++ b/bin/xbps-remove/clean-cache.c
@@ -38,8 +38,8 @@
 
 static int
 cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj,
-		const char *key _unused, void *arg,
-		bool *done _unused)
+		const char *key UNUSED, void *arg,
+		bool *done UNUSED)
 {
 	xbps_dictionary_t repo_pkgd;
 	const char *binpkg, *rsha256;

--- a/bin/xbps-remove/main.c
+++ b/bin/xbps-remove/main.c
@@ -64,7 +64,7 @@ usage(bool fail)
 }
 
 static int
-state_cb_rm(const struct xbps_state_cb_data *xscd, void *cbdata _unused)
+state_cb_rm(const struct xbps_state_cb_data *xscd, void *cbdata UNUSED)
 {
 	bool slog = false;
 

--- a/bin/xbps-rindex/index-clean.c
+++ b/bin/xbps-rindex/index-clean.c
@@ -43,9 +43,9 @@ static xbps_dictionary_t dest;
 static int
 idx_cleaner_cb(struct xbps_handle *xhp,
 		xbps_object_t obj,
-		const char *key _unused,
+		const char *key UNUSED,
 		void *arg,
-		bool *done _unused)
+		bool *done UNUSED)
 {
 	const char *repourl = arg;
 	const char *arch, *pkgver, *sha256;

--- a/bin/xbps-rindex/remove-obsoletes.c
+++ b/bin/xbps-rindex/remove-obsoletes.c
@@ -65,7 +65,7 @@ remove_pkg(const char *repodir, const char *file)
 }
 
 static int
-cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj, const char *key _unused, void *arg, bool *done _unused)
+cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj, const char *key UNUSED, void *arg, bool *done UNUSED)
 {
 	struct xbps_repo *repo = ((struct xbps_repo **)arg)[0], *stage = ((struct xbps_repo **)arg)[1];
 	const char *binpkg;

--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -109,8 +109,8 @@ die(const char *fmt, ...)
 }
 
 static int
-ftw_cb(const char *fpath, const struct stat *sb _unused, int type,
-		struct FTW *ftwbuf _unused)
+ftw_cb(const char *fpath, const struct stat *sb UNUSED, int type,
+		struct FTW *ftwbuf UNUSED)
 {
 	int sverrno = 0;
 

--- a/configure
+++ b/configure
@@ -192,7 +192,7 @@ echo "CPPFLAGS +=	-DXBPS_SYSCONF_PATH=\\\"${ETCDIR}\\\"" >>$CONFIG_MK
 echo "CPPFLAGS +=	-DXBPS_SYSDEFCONF_PATH=\\\"${SHAREDIR}/xbps.d\\\"" >>$CONFIG_MK
 echo "CPPFLAGS +=	-DXBPS_VERSION=\\\"${VERSION}\\\"" >>$CONFIG_MK
 echo "CPPFLAGS +=	-DXBPS_META_PATH=\\\"${DBDIR}\\\"" >>$CONFIG_MK
-echo "CPPFLAGS +=	-D_unused=\"__attribute__((__unused__))\"" >>$CONFIG_MK
+echo "CPPFLAGS +=	-DUNUSED=\"__attribute__((__unused__))\"" >>$CONFIG_MK
 
 if [ -d .git ]; then
 	_gitrev=$(git rev-parse --short HEAD)

--- a/lib/package_orphans.c
+++ b/lib/package_orphans.c
@@ -60,7 +60,7 @@
  */
 
 xbps_array_t
-xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user _unused)
+xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user UNUSED)
 {
 	xbps_array_t rdeps, reqby, array = NULL;
 	xbps_dictionary_t pkgd, deppkgd;

--- a/lib/plist_fetch.c
+++ b/lib/plist_fetch.c
@@ -46,7 +46,7 @@ struct fetch_archive {
 };
 
 static int
-fetch_archive_open(struct archive *a _unused, void *client_data)
+fetch_archive_open(struct archive *a UNUSED, void *client_data)
 {
 	struct fetch_archive *f = client_data;
 
@@ -59,7 +59,7 @@ fetch_archive_open(struct archive *a _unused, void *client_data)
 }
 
 static ssize_t
-fetch_archive_read(struct archive *a _unused, void *client_data, const void **buf)
+fetch_archive_read(struct archive *a UNUSED, void *client_data, const void **buf)
 {
 	struct fetch_archive *f = client_data;
 
@@ -68,7 +68,7 @@ fetch_archive_read(struct archive *a _unused, void *client_data, const void **bu
 }
 
 static int
-fetch_archive_close(struct archive *a _unused, void *client_data)
+fetch_archive_close(struct archive *a UNUSED, void *client_data)
 {
 	struct fetch_archive *f = client_data;
 

--- a/lib/rpool.c
+++ b/lib/rpool.c
@@ -120,7 +120,7 @@ xbps_rpool_get_repo(const char *url)
 }
 
 void
-xbps_rpool_release(struct xbps_handle *xhp _unused)
+xbps_rpool_release(struct xbps_handle *xhp UNUSED)
 {
 	struct xbps_repo *repo;
 
@@ -195,7 +195,7 @@ find_pkg_cb(struct xbps_repo *repo, void *arg, bool *done)
 }
 
 static int
-find_pkg_revdeps_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
+find_pkg_revdeps_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
 {
 	struct rpool_fpkg *rpf = arg;
 	xbps_array_t revdeps = NULL;
@@ -216,7 +216,7 @@ find_pkg_revdeps_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
 }
 
 static int
-find_best_pkg_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
+find_best_pkg_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
 {
 	struct rpool_fpkg *rpf = arg;
 	xbps_dictionary_t pkgd;

--- a/lib/transaction_conflicts.c
+++ b/lib/transaction_conflicts.c
@@ -148,7 +148,7 @@ pkg_conflicts_trans(struct xbps_handle *xhp, xbps_array_t array,
 
 static int
 pkgdb_conflicts_cb(struct xbps_handle *xhp, xbps_object_t obj,
-		const char *key _unused, void *arg, bool *done _unused)
+		const char *key UNUSED, void *arg, bool *done UNUSED)
 {
 	xbps_array_t pkg_cflicts, trans_cflicts, pkgs = arg;
 	xbps_dictionary_t pkgd;


### PR DESCRIPTION
Identifiers that starts with underscore are reserved so we rename
_unused to UNUSED.

This fixes build on Alpine Linux ppc64le.